### PR TITLE
Quick fixes to name and email

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: conrad
 Title: Client for the Microsoft's 'Cognitive Services Text to Speech REST' API
 Version: 1.0.0.9000
 Authors@R: c( 
-    person("Howard", "Baek", email = "howardbaek.fh@gmail.com", role = c("aut", "cre", "cph"),
+    person("Howard", "Baik", email = "howardbaik43@gmail.com", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0009-0000-8942-1618")),
     person("John", "Muschelli", email = "muschellij2@gmail.com", role = c("aut"),
            comment = c(ORCID = "0000-0001-6469-1750"))

--- a/codemeta.json
+++ b/codemeta.json
@@ -16,8 +16,8 @@
     {
       "@type": "Person",
       "givenName": "Howard",
-      "familyName": "Baek",
-      "email": "howardbaek.fh@gmail.com",
+      "familyName": "Baik",
+      "email": "howardbaik43@gmail.com",
       "@id": "https://orcid.org/0009-0000-8942-1618"
     },
     {
@@ -32,8 +32,8 @@
     {
       "@type": "Person",
       "givenName": "Howard",
-      "familyName": "Baek",
-      "email": "howardbaek.fh@gmail.com",
+      "familyName": "Baik",
+      "email": "howardbaik43@gmail.com",
       "@id": "https://orcid.org/0009-0000-8942-1618"
     }
   ],
@@ -41,8 +41,8 @@
     {
       "@type": "Person",
       "givenName": "Howard",
-      "familyName": "Baek",
-      "email": "howardbaek.fh@gmail.com",
+      "familyName": "Baik",
+      "email": "howardbaik43@gmail.com",
       "@id": "https://orcid.org/0009-0000-8942-1618"
     }
   ],


### PR DESCRIPTION
@cansavvy Here is a quick fix:

I'm using my legal name, Howard Baik, to avoid future confusion, and am using my personal Gmail (howardbaik43@gmail.com) instead of my work Gmail (howardbaek.fh@gmail.com)